### PR TITLE
fix: add outputDetail fields to Submission class

### DIFF
--- a/src/lib/submission.ts
+++ b/src/lib/submission.ts
@@ -1,4 +1,5 @@
 import Helper from "@/utils/helper";
+import { OutputDetail } from "@/utils/interfaces";
 
 class Submission {
     constructor(
@@ -9,7 +10,10 @@ class Submission {
         public statusDisplay?: string,
         public timestamp?: number,
         public code?: string,
-        public sourceUrl?: string
+        public sourceUrl?: string,
+        public passedTestCaseCnt?: number,
+        public totalTestCaseCnt?: number,
+        public outputDetail?: OutputDetail
     ) {}
 
     static async build(id: number): Promise<Submission> {
@@ -79,6 +83,9 @@ class Submission {
             "$id",
             this.id.toString()
         );
+        this.passedTestCaseCnt = submissionDetail.passedTestCaseCnt;
+        this.totalTestCaseCnt = submissionDetail.totalTestCaseCnt;
+        this.outputDetail = submissionDetail.outputDetail;
 
         return this;
     }

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -182,3 +182,13 @@ export interface Uris {
     submit: string;
     submission: string;
 }
+
+export interface OutputDetail {
+    codeOutput: string;
+    expectedOutput: string;
+    input: string;
+    compileError: string;
+    runtimeError: string;
+    lastTestcase: string;
+    __typename: string;
+}

--- a/test/submission.ts
+++ b/test/submission.ts
@@ -54,5 +54,19 @@ describe("# Submission", async function () {
         expect(submission.statusDisplay).to.be.a("string");
         expect(submission.timestamp).to.be.an("number");
         expect(submission.code).to.be.a("string");
+        expect(submission.passedTestCaseCnt).to.be.an("number");
+        expect(submission.totalTestCaseCnt).to.be.an("number");
+        expect(submission.sourceUrl).to.be.a("string");
+
+        expect(submission.outputDetail.codeOutput).to.be.an("string");
+        expect(submission.outputDetail.expectedOutput).to.be.an("string");
+        expect(submission.outputDetail.input).to.be.an("string");
+        expect(submission.outputDetail.compileError).to.be.an("string");
+        expect(submission.outputDetail.runtimeError).to.be.an("string");
+        expect(submission.outputDetail.lastTestcase).to.be.an("string");
+        expect(submission.outputDetail.__typename).to.be.equal("SubmissionOutputNode");
+        
+        
+
     });
 });


### PR DESCRIPTION
Add outputDetail fields for more info if the submission failed. Tests failed because they failed to log in.